### PR TITLE
Use NodePort instead of LoadBalancer for ingress

### DIFF
--- a/.kube.yml
+++ b/.kube.yml
@@ -29,7 +29,7 @@ metadata:
   labels:
     apps: {{.app}}-{{.env}}
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
     - name: http
       protocol: TCP


### PR DESCRIPTION
We don't need a load balancer for every running instance.